### PR TITLE
Fixes: Use RESTIfaceCollection is unique to a give root

### DIFF
--- a/icontrol/test/test_session.py
+++ b/icontrol/test/test_session.py
@@ -20,9 +20,7 @@ from icontrol import session
 
 @pytest.fixture()
 def iCRS():
-    mock_bigip_icr_uri = 'https://0.0.0.0/mgmt/tm/'
-    fake_iCRS = session.iControlRESTSession(mock_bigip_icr_uri, 'admin',
-                                            'admin')
+    fake_iCRS = session.iControlRESTSession('admin', 'admin')
     fake_iCRS.session = mock.MagicMock()
     mock_response = mock.MagicMock()
     mock_response.status_code = 200
@@ -36,8 +34,7 @@ def iCRS():
 
 @pytest.fixture()
 def uparts():
-    parts_dict = {'bigip_icr_uri': 'https://0.0.0.0/mgmt/tm/',
-                  'prefix_collections': 'ltm/bar/',
+    parts_dict = {'base_uri': 'https://0.0.0.0/mgmt/tm/root/RESTiface/',
                   'folder': 'BIGCUSTOMER',
                   'instance_name': 'foobar1',
                   'suffix': '/members/m1'}
@@ -46,44 +43,26 @@ def uparts():
 
 # Test uri component validation
 def test_incorrect_uri_construction_bad_scheme(uparts):
-    uparts['bigip_icr_uri'] = 'hryttps://0.0.0.0/mgmt/tm/'
+    uparts['base_uri'] = 'hryttps://0.0.0.0/mgmt/tm/root/RESTiface/'
     with pytest.raises(session.InvalidScheme) as IS:
         session.generate_bigip_uri(**uparts)
     assert IS.value.message == 'hryttps'
 
 
 def test_incorrect_uri_construction_bad_mgmt_path(uparts):
-    uparts['bigip_icr_uri'] = 'https://0.0.0.0/magmt/tm/'
+    uparts['base_uri'] = 'https://0.0.0.0/magmt/tm/root/RESTiface'
     with pytest.raises(session.InvalidBigIP_ICRURI) as IR:
         session.generate_bigip_uri(**uparts)
-    assert IR.value.message == '/magmt/tm/'
+    assert IR.value.message ==\
+        "The path must start with '/mgmt/tm/'!!  But it's: '/magmt/tm/'"
 
 
 def test_incorrect_uri_construction_bad_base_nonslash_last(uparts):
-    uparts['bigip_icr_uri'] = 'https://0.0.0.0/mgmt/tm'
-    with pytest.raises(session.InvalidBigIP_ICRURI) as IR:
-        session.generate_bigip_uri(**uparts)
-    test_value = "The bigip_icr_uri must end with '/'!!  But it's: /mgmt/tm"
-    assert IR.value.message == test_value
-
-
-def test_incorrect_uri_construction_bad_prefix_collection_wrong_start(uparts):
-    uparts['prefix_collections'] = '/actions/bar/'
+    uparts['base_uri'] = 'https://0.0.0.0/mgmt/tm/root/RESTiface'
     with pytest.raises(session.InvalidPrefixCollection) as IR:
         session.generate_bigip_uri(**uparts)
-    test_value =\
-        "prefix_collections element must not start with '/', but it's: %s"\
-        % uparts['prefix_collections']
-    assert IR.value.message == test_value
-
-
-def test_incorrect_uri_construction_bad_prefix_collection_wrong_end(uparts):
-    uparts['prefix_collections'] = 'actions/bar'
-    with pytest.raises(session.InvalidPrefixCollection) as IR:
-        session.generate_bigip_uri(**uparts)
-    test_value =\
-        "prefix_collections path element must end with '/', but it's: %s"\
-        % uparts['prefix_collections']
+    test_value = "prefix_collections path element must end with '/', but" +\
+        " it's: root/RESTiface"
     assert IR.value.message == test_value
 
 
@@ -127,20 +106,21 @@ def test_incorrect_uri_construction_illegal_suffix_slash_last(uparts):
 def test_correct_uri_construction_folderless(uparts):
     uparts['folder'] = ''
     uri = session.generate_bigip_uri(**uparts)
-    assert uri == 'https://0.0.0.0/mgmt/tm/ltm/bar/~foobar1/members/m1'
+    assert uri == 'https://0.0.0.0/mgmt/tm/root/RESTiface/~foobar1/members/m1'
 
 
 def test_correct_uri_construction_nameless(uparts):
     uparts['instance_name'] = ''
     uri = session.generate_bigip_uri(**uparts)
-    assert uri == "https://0.0.0.0/mgmt/tm/ltm/bar/~BIGCUSTOMER/members/m1"
+    assert uri ==\
+        "https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER/members/m1"
 
 
 def test_correct_uri_construction_folderless_and_nameless(uparts):
     uparts['folder'] = ''
     uparts['instance_name'] = ''
     uri = session.generate_bigip_uri(**uparts)
-    assert uri == "https://0.0.0.0/mgmt/tm/ltm/bar/members/m1"
+    assert uri == "https://0.0.0.0/mgmt/tm/root/RESTiface/members/m1"
 
 
 def test_correct_uri_construction_folder_name_and_suffixless(uparts):
@@ -148,74 +128,74 @@ def test_correct_uri_construction_folder_name_and_suffixless(uparts):
     uparts['instance_name'] = ''
     uparts['suffix'] = ''
     uri = session.generate_bigip_uri(**uparts)
-    assert uri == "https://0.0.0.0/mgmt/tm/ltm/bar/"
+    assert uri == "https://0.0.0.0/mgmt/tm/root/RESTiface/"
 
 
 def test_correct_uri_construction_folderless_and_suffixless(uparts):
     uparts['folder'] = ''
     uparts['suffix'] = ''
     uri = session.generate_bigip_uri(**uparts)
-    assert uri == 'https://0.0.0.0/mgmt/tm/ltm/bar/~foobar1'
+    assert uri == 'https://0.0.0.0/mgmt/tm/root/RESTiface/~foobar1'
 
 
 def test_correct_uri_construction_nameless_and_suffixless(uparts):
     uparts['instance_name'] = ''
     uparts['suffix'] = ''
     uri = session.generate_bigip_uri(**uparts)
-    assert uri == 'https://0.0.0.0/mgmt/tm/ltm/bar/~BIGCUSTOMER'
+    assert uri == 'https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER'
 
 
 # Test exception handling
-def test_wrapped_delete_success(iCRS):
-    iCRS.delete('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+def test_wrapped_delete_success(iCRS, uparts):
+    iCRS.delete(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
 
 
-def test_wrapped_delete_207_fail(iCRS):
+def test_wrapped_delete_207_fail(iCRS, uparts):
     iCRS.session.delete.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.delete('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.delete(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')
 
 
-def test_wrapped_get_success(iCRS):
-    iCRS.get('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+def test_wrapped_get_success(iCRS, uparts):
+    iCRS.get(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
 
 
-def test_wrapped_get_207_fail(iCRS):
+def test_wrapped_get_207_fail(iCRS, uparts):
     iCRS.session.get.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.get('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.get(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')
 
 
-def test_wrapped_patch_success(iCRS):
-    iCRS.patch('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+def test_wrapped_patch_success(iCRS, uparts):
+    iCRS.patch(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
 
 
-def test_wrapped_patch_207_fail(iCRS):
+def test_wrapped_patch_207_fail(iCRS, uparts):
     iCRS.session.patch.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.patch('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.patch(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')
 
 
-def test_wrapped_post_success(iCRS):
-    iCRS.post('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+def test_wrapped_post_success(iCRS, uparts):
+    iCRS.post(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
 
 
-def test_wrapped_post_207_fail(iCRS):
+def test_wrapped_post_207_fail(iCRS, uparts):
     iCRS.session.post.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.post('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.post(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')
 
 
-def test_wrapped_put_success(iCRS):
-    iCRS.put('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+def test_wrapped_put_success(iCRS, uparts):
+    iCRS.put(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
 
 
-def test_wrapped_put_207_fail(iCRS):
+def test_wrapped_put_207_fail(iCRS, uparts):
     iCRS.session.put.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.put('ltm/nat/', 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.put(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')


### PR DESCRIPTION
#### What does this address?

Fixes #7
What this change do?

Updates the iControlRESTSession class, since the base_uri is now composed by the concrete subclass of the RESTInterfaceCollection abstract class. It also updates the unittests for the iControlRESTSession class.
#### Where should the reviewer start?

py.test -v -s icontrol/test/test_session.py
#### Any background context?

In a the earlier version of the code the responsibility to compose the bigip.icr_uri, and the RESTInterfaceCollection path fragment was being handled by the iControlRESTSession class. In the new version that responsibility is moved into the concrete subclasses of RESTInterfaceCollection (specifically in their init methods).
