### PR TITLE
Functional tests for session

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install requests hacking pytest pytest-cov
 script:
     - flake8 .
-    - py.test --cov .
+    - py.test --cov --ignore=test/
 notifications:
     slack:
       rooms:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+
+# Test Requirements
+pytest
+pytest-coverage
+hacking

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'wormke'

--- a/test/functional/__init__.py
+++ b/test/functional/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'wormke'

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -1,0 +1,70 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from icontrol.session import iControlRESTSession
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--bigip", action="store",
+                     help="BIG-IP hostname or IP address")
+    parser.addoption("--username", action="store", help="BIG-IP REST username",
+                     default="admin")
+    parser.addoption("--password", action="store", help="BIG-IP REST password",
+                     default="admin")
+
+
+def pytest_generate_tests(metafunc):
+    assert metafunc.config.option.bigip
+
+
+@pytest.fixture
+def opt_bigip(request):
+    return request.config.getoption("--bigip")
+
+
+@pytest.fixture
+def opt_username(request):
+    return request.config.getoption("--username")
+
+
+@pytest.fixture
+def opt_password(request):
+    return request.config.getoption("--password")
+
+
+@pytest.fixture
+def ICR(opt_bigip, opt_username, opt_password):
+    icr = iControlRESTSession(opt_username, opt_password)
+    return icr
+
+
+@pytest.fixture
+def GET_URL(opt_bigip):
+    url = 'https://' + opt_bigip + '/mgmt/tm/ltm/nat/'
+    return url
+
+
+@pytest.fixture
+def POST_URL(opt_bigip):
+    url = 'https://' + opt_bigip + '/mgmt/tm/ltm/nat/'
+    return url
+
+
+@pytest.fixture
+def FAKE_URL(opt_bigip):
+    fake_url = 'https://' + opt_bigip + '/mgmt/tm/bogus/'
+    return fake_url

--- a/test/functional/test_session.py
+++ b/test/functional/test_session.py
@@ -1,0 +1,211 @@
+# Copyright 2015 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+'''This test suite attempts to test the things that a real BIGIP device is
+required for that unit testing cannot test.  For example the unit tests can
+cover the case in which the beginning of the URL is correct up to the
+collection object i.e. https://192.168.1.1/mgmt/tm/  It cannot test that
+the collection objects that are after that are correct
+i.e https://192.168.1.1/mgmt/tm/boguscollection
+'''
+
+from icontrol.session import iControlRESTSession
+from requests.exceptions import HTTPError
+
+import pytest
+
+nat_data = {
+    'name': 'foo',
+    'partition': 'Common',
+    'originatingAddress': '192.168.1.1',
+    'translationAddress': '192.168.2.1',
+}
+
+
+def teardown_nat(request, icr, url, name, folder):
+    '''Remove the nat object that we create during a test '''
+    def teardown():
+        icr.delete(url, instance_name=name, folder=folder)
+    request.addfinalizer(teardown)
+
+
+def invalid_url(func, url):
+    '''Reusable test to make sure that we get 404 for invalid URL '''
+    with pytest.raises(HTTPError) as err:
+        func(url)
+    return (err.value.response.status_code == 404 and
+            '404 Client Error: Not Found for url: ' + url
+            in err.value.message)
+
+
+def invalid_credentials(user, password, url):
+    '''Reusable test to make sure that we get 401 for invalid creds '''
+    icr = iControlRESTSession(user, password)
+    with pytest.raises(HTTPError) as err:
+        icr.get(url)
+    return (err.value.response.status_code == 401 and
+            '401 Client Error: F5 Authorization Required' in err.value.message)
+
+
+def test_get(ICR, GET_URL):
+    '''Test a GET request to a valid url
+
+    Pass: Returns a 200 with proper json
+    '''
+    response = ICR.get(GET_URL)
+    assert response.status_code == 200
+    assert response.json()
+
+
+def test_get_invalid_url(ICR, FAKE_URL):
+    '''Test a GET to an invalid URL.
+
+    Pass: Returns a 404 with a proper message
+    '''
+    assert invalid_url(ICR.get, FAKE_URL)
+
+
+def test_post(request, ICR, POST_URL):
+    '''Test a POST request to a valid url
+
+    Pass: Returns a 200 and the json object is set correctly
+    '''
+    teardown_nat(
+        request, ICR, POST_URL, nat_data['name'], nat_data['partition'])
+    response = ICR.post(POST_URL, json=nat_data)
+    response_data = response.json()
+    assert response.status_code == 200
+    assert(response_data['name'] == nat_data['name'])
+    assert(response_data['partition'] == nat_data['partition'])
+    assert(response_data['originatingAddress'] ==
+           nat_data['originatingAddress'])
+    assert(response_data['translationAddress'] ==
+           nat_data['translationAddress'])
+
+
+def test_post_invalid_url(ICR, FAKE_URL):
+    '''Test a POST request to an invalid url.
+
+    Pass: Returns a 404 with a proper message
+    '''
+    assert invalid_url(ICR.post, FAKE_URL)
+
+
+def test_put(request, ICR, POST_URL):
+    '''Test a PUT request to a valid url.
+
+    Pass: Returns a 200 and the json object is set correctly
+    '''
+    data = {'originatingAddress': '192.168.1.50'}
+    teardown_nat(
+        request, ICR, POST_URL, nat_data['name'], nat_data['partition'])
+    ICR.post(POST_URL, json=nat_data)
+    response = ICR.put(
+        POST_URL,
+        instance_name=nat_data['name'],
+        folder=nat_data['partition'],
+        json=data)
+    response_data = response.json()
+    assert response.status_code == 200
+    assert response_data['originatingAddress'] == data['originatingAddress']
+    assert response_data['name'] == nat_data['name']
+    assert response_data['partition'] == nat_data['partition']
+    assert response_data['translationAddress'] == \
+        nat_data['translationAddress']
+
+
+def test_put_invalid_url(ICR, FAKE_URL):
+    '''Test a PUT request to an invalid url.
+
+    Pass: Return a 404 with a proper error message
+    '''
+    assert invalid_url(ICR.put, FAKE_URL)
+
+
+def test_patch(request, ICR, POST_URL):
+    '''Test a PATCH request to a valid url.
+
+    Pass: Returns a 200 and the json object is set correctly
+    '''
+    data = {'originatingAddress': '192.168.1.50'}
+    teardown_nat(
+        request, ICR, POST_URL, nat_data['name'], nat_data['partition'])
+    ICR.post(POST_URL, json=nat_data)
+    response = ICR.patch(
+        POST_URL,
+        instance_name=nat_data['name'],
+        folder=nat_data['partition'],
+        json=data)
+    response_data = response.json()
+    assert response.status_code == 200
+    assert response_data['originatingAddress'] == data['originatingAddress']
+    assert response_data['name'] == nat_data['name']
+    assert response_data['partition'] == nat_data['partition']
+    assert response_data['translationAddress'] == \
+        nat_data['translationAddress']
+
+
+def test_patch_invalid_url(ICR, FAKE_URL):
+    '''Test a PATCH request to an invalid url.
+
+    Pass: Return a 404 with a proper error message
+    '''
+    assert invalid_url(ICR.patch, FAKE_URL)
+
+
+def test_delete(request, ICR, POST_URL):
+    '''Test a DELETE request to a valid url.
+
+    Pass: Return a 200 and the json is empty.  Subsequent GET returns a 404
+    error because the object is no longer found.
+    '''
+    ICR.post(POST_URL, json=nat_data)
+    response = ICR.delete(
+        POST_URL,
+        instance_name=nat_data['name'],
+        folder=nat_data['partition'])
+    assert response.status_code == 200
+    with pytest.raises(ValueError):
+        response.json()
+
+    with pytest.raises(HTTPError) as err:
+        ICR.get(
+            POST_URL,
+            instance_name=nat_data['name'],
+            folder=nat_data['partition'])
+    assert err.value.response.status_code == 404
+
+
+def test_delete_invalid_url(ICR, FAKE_URL):
+    '''Test a DELETE request to an invalid url.
+
+    Pass: Return a 404 with a proper error message
+    '''
+    assert invalid_url(ICR.delete, FAKE_URL)
+
+
+def test_invalid_user(opt_password, GET_URL):
+    '''Test login with an invalid username and valid password
+
+    Pass: Returns 401 with authorization required message
+    '''
+    invalid_credentials('fakeuser', opt_password, GET_URL)
+
+
+def test_invalid_password(opt_username, GET_URL):
+    '''Test login with a valid username and invalid password
+
+    Pass: Returns 401 with authorization required message
+    '''
+    invalid_credentials(opt_username, 'fakepassword', GET_URL)


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?

Fixes #31 
#### What's this change do?

Adds functional tests for the icontrol.session module.
#### Where should the reviewer start?

Look at the files in `test/functional/`
#### Any background context?

The approach I took was to write tests for things that you could really only test with a real BIGIP.  For example I wrote some negative user/password tests and then exercised the verbs.  I also wrote tests for each verb to make sure they handled going to a URL that passes the checker, but is still invalid on the device.
