### PR TITLE
Feature.two mode ops

### DIFF
--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -195,8 +195,9 @@ def _log_HTTP_verb_method_postcall(logger, level, response):
 def decorate_HTTP_verb_method(method):
     # NOTE:  "self" refers to a RESTInterfaceCollection instance!
     @functools.wraps(method)
-    def wrapper(self, RIC_base_uri, partition='', name='',
-                **kwargs):
+    def wrapper(self, RIC_base_uri, **kwargs):
+        partition = kwargs.pop('partition', '')
+        name = kwargs.pop('name', '')
         suffix = kwargs.pop('suffix', '')
         uri_as_parts = kwargs.pop('uri_as_parts', False)
         if uri_as_parts:

--- a/icontrol/test/test_session.py
+++ b/icontrol/test/test_session.py
@@ -154,7 +154,8 @@ def test_correct_uri_construction_nameless_and_suffixless(uparts):
 
 # Test exception handling
 def test_wrapped_delete_success(iCRS, uparts):
-    iCRS.delete(uparts['base_uri'], 'AFN', 'AIN', uri_as_parts=True)
+    iCRS.delete(uparts['base_uri'], partition='AFN', name='AIN',
+                uri_as_parts=True)
     assert iCRS.session.delete.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN')
 
@@ -162,18 +163,21 @@ def test_wrapped_delete_success(iCRS, uparts):
 def test_wrapped_delete_207_fail(iCRS, uparts):
     iCRS.session.delete.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.delete(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.delete(uparts['base_uri'], partition='A_FOLDER_NAME',
+                    name='AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')
 
 
 def test_wrapped_get_success(iCRS, uparts):
-    iCRS.get(uparts['base_uri'], 'AFN', 'AIN', uri_as_parts=True)
+    iCRS.get(uparts['base_uri'], partition='AFN', name='AIN',
+             uri_as_parts=True)
     assert iCRS.session.get.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN')
 
 
 def test_wrapped_get_success_with_suffix(iCRS, uparts):
-    iCRS.get(uparts['base_uri'], 'AFN', 'AIN', suffix=uparts['suffix'],
+    iCRS.get(uparts['base_uri'], partition='AFN', name='AIN',
+             suffix=uparts['suffix'],
              uri_as_parts=True)
     assert iCRS.session.get.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN/members/m1')
@@ -182,12 +186,14 @@ def test_wrapped_get_success_with_suffix(iCRS, uparts):
 def test_wrapped_get_207_fail(iCRS, uparts):
     iCRS.session.get.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.get(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.get(uparts['base_uri'], partition='A_FOLDER_NAME',
+                 name='AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')
 
 
 def test_wrapped_patch_success(iCRS, uparts):
-    iCRS.patch(uparts['base_uri'], 'AFN', 'AIN', uri_as_parts=True)
+    iCRS.patch(uparts['base_uri'], partition='AFN', name='AIN',
+               uri_as_parts=True)
     assert iCRS.session.patch.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN', data=None)
 
@@ -195,33 +201,37 @@ def test_wrapped_patch_success(iCRS, uparts):
 def test_wrapped_patch_207_fail(iCRS, uparts):
     iCRS.session.patch.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.patch(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.patch(uparts['base_uri'], partition='A_FOLDER_NAME',
+                   name='AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')
 
 
 def test_wrapped_put_207_fail(iCRS, uparts):
     iCRS.session.put.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.put(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.put(uparts['base_uri'], partition='A_FOLDER_NAME',
+                 name='AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')
 
 
 def test_wrapped_post_207_fail(iCRS, uparts):
     iCRS.session.post.return_value.status_code = 207
     with pytest.raises(session.iControlUnexpectedHTTPError) as CHE:
-        iCRS.post(uparts['base_uri'], 'A_FOLDER_NAME', 'AN_INSTANCE_NAME')
+        iCRS.post(uparts['base_uri'], partition='A_FOLDER_NAME',
+                  name='AN_INSTANCE_NAME')
     assert CHE.value.message.startswith('207 Unexpected Error: ')
 
 
 def test_wrapped_post_success(iCRS, uparts):
-    iCRS.post(uparts['base_uri'], 'AFN', 'AIN', uri_as_parts=True)
+    iCRS.post(uparts['base_uri'], partition='AFN', name='AIN',
+              uri_as_parts=True)
     assert iCRS.session.post.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN', data=None,
                   json=None)
 
 
 def test_wrapped_post_success_with_data(iCRS, uparts):
-    iCRS.post(uparts['base_uri'], 'AFN', 'AIN', data={'a': 1},
+    iCRS.post(uparts['base_uri'], partition='AFN', name='AIN', data={'a': 1},
               uri_as_parts=True)
     assert iCRS.session.post.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN',
@@ -229,7 +239,7 @@ def test_wrapped_post_success_with_data(iCRS, uparts):
 
 
 def test_wrapped_post_success_with_json(iCRS, uparts):
-    iCRS.post(uparts['base_uri'], 'AFN', 'AIN', json='{"a": 1}',
+    iCRS.post(uparts['base_uri'], partition='AFN', name='AIN', json='{"a": 1}',
               uri_as_parts=True)
     assert iCRS.session.post.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN', data=None,
@@ -237,21 +247,22 @@ def test_wrapped_post_success_with_json(iCRS, uparts):
 
 
 def test_wrapped_post_success_with_json_and_data(iCRS, uparts):
-    iCRS.post(uparts['base_uri'], 'AFN', 'AIN', data={'a': 1}, json='{"a": 1}',
-              uri_as_parts=True)
+    iCRS.post(uparts['base_uri'], partition='AFN', name='AIN', data={'a': 1},
+              json='{"a": 1}', uri_as_parts=True)
     assert iCRS.session.post.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN',
                   data={'a': 1}, json='{"a": 1}')
 
 
 def test_wrapped_put_success(iCRS, uparts):
-    iCRS.put(uparts['base_uri'], 'AFN', 'AIN', uri_as_parts=True)
+    iCRS.put(uparts['base_uri'], partition='AFN', name='AIN',
+             uri_as_parts=True)
     assert iCRS.session.put.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN', data=None)
 
 
 def test_wrapped_put_success_with_data(iCRS, uparts):
-    iCRS.put(uparts['base_uri'], 'AFN', 'AIN', data={'b': 2},
+    iCRS.put(uparts['base_uri'], partition='AFN', name='AIN', data={'b': 2},
              uri_as_parts=True)
     assert iCRS.session.put.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN',


### PR DESCRIPTION
@swormke 
#### This addresses the need for two modes of operation:
1. The uri is known to the User by its parts (e.g. partition and name)
2. The uri is known to the User as a complete uri (e.g. nat_object_1.meta_data['uri'])  <-- BTW, a
   consumer of the f5-common-python library would not call Foo.meta_data directly, instead they would
   call `Foo.update(), Foo.read(), etc.`.   If a consumer of f5-common-python were curious about the
   device's representation of a resource's uri they could do something like:
   
      `print Foo.selfLink`

Fixes #34 
#### This change makes REST HTTP verb methods take a single positional argument (besides self), that argument is a uri, but whether it's a complete uri or not must be specified by the `uri_as_parts` boolean (which defaults to `False`).
#### The reviewer should start by running the unittests, then inspect the `wrapper` function inside the `decorate_HTTP_verb_method` function:

https://github.com/zancas/f5-icontrol-rest-python/blob/feature.two_mode_ops/icontrol/session.py#L198
#### Background:

We don't want library Users to assemble their own URI's, but this change facilitates that mode of operation, since Users will get the response they expect if they simply drop a complete-and-correct uri into the HTTP verb method they're using.  Perhaps we should just switch the default value of `uri_as_parts` to True, this would force User's to explicitly turn off uri assembly, which would at least force them to be explicit.
1. Never assemble 
