### PR TITLE
Non 200 status-codes output response.text

### DIFF
--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -185,10 +185,11 @@ def _log_HTTP_verb_method_precall(logger, methodname, level, cls_name,
 
 def _log_HTTP_verb_method_postcall(logger, level, response):
     post_message = "RESPONSE::STATUS:" +\
-                   " %s Content-Type: %s Content-Encoding: %s" %\
+                   " %s Content-Type: %s Content-Encoding: %s\nText: %r" %\
         (response.status_code,
          response.headers.get('Content-Type', None),
-         response.headers.get('Content-Encoding', None))
+         response.headers.get('Content-Encoding', None),
+         response.text)
     logger.log(level, post_message)
 
 
@@ -212,12 +213,12 @@ def decorate_HTTP_verb_method(method):
                                       REST_uri, suffix, **kwargs)
         response = method(self, REST_uri, **kwargs)
         _log_HTTP_verb_method_postcall(logger, self.log_level, response)
-        response.raise_for_status()
         if response.status_code not in range(200, 207):
-            error_message = '%s Unexpected Error: %s for uri: %s' %\
+            error_message = '%s Unexpected Error: %s for uri: %s\nText: %r' %\
                             (response.status_code,
                              response.reason,
-                             response.uri)
+                             response.url,
+                             response.text)
             raise iControlUnexpectedHTTPError(error_message, response=response)
         return response
     return wrapper

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests
+requests >= 2.9.1
 
 # Test Requirements
 pytest


### PR DESCRIPTION
@swormke  You requested this a couple of weeks ago.
Issues:
Fixes # https://github.com/F5Networks/f5-icontrol-rest-python/issues/38
also, updates requirements.txt
Fixes # https://github.com/F5Networks/f5-icontrol-rest-python/issues/36

Problem: It's hard to debug without the response.text

Analysis: non-200 status_codes usually report a reason in the
response.text, so the library now logs, and exports that string
as an exception "message"

Tests: development-manual-functional
