### PR TITLE
Add required license and support documentation for F5 public repos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,12 +24,6 @@ Creating issues is good, creating good issues is even better.  By filing meaning
  in them helps us figure out what to fix when and how it impacts our users.  We like bugs because it means people are
  using our code, and we like fixing them even more.
  
-### Bugs
-TODO: What do we want in our bug reports and an example?
-
-### Feature Requests and Enhancements
-TODO: What do we want in our bug reports and an example?
-
 ## Pull Requests
 If you are submitting a pull request you need to make sure that you have done a few things first.
 
@@ -69,6 +63,21 @@ tests but the maintainers and consumers of this code appreciate the effort and
  If you are running our functional tests you will need a real BIG-IP to run
  them against, but you can get one of those pretty easily in [Amazon EC2](https://aws.amazon.com/marketplace/pp/B00JL3UASY/ref=srh_res_product_title?ie=UTF8&sr=0-10&qid=1449332167461).
 
-## Contributor License Agreement
-TODO: Need to get this from legal
-
+## License
+ 
+### Apache V2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ 
+### Contributor License Agreement
+Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html) to Openstack_CLA@f5.com prior to their
+code submission being included in this project.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,105 @@
 # f5-icontrol-rest-python
-Generic python library that allows programs and other modules to interact with the BIG-IP iControl REST API.
+[![Build Status](https://travis-ci.com/F5Networks/f5-icontrol-rest-python.svg?token=2gRRgdSNRf2z9jAftSpV)](https://travis-ci.com/F5Networks/f5-icontrol-rest-python)
 
-# Build
-To make a py-pi package run:
-$ python setup.py sdist
+## Introduction
+This generic python library allows programs and other modules to interact with the BIG-IP iControl REST API.
+
+## Installation
+### Using Pip
+```bash
+pip install f5-icontrol-rest
+```
+
+### Installing directly from GitHub
+*Note:* This will install the package at release v0.1.0.
+```bash
+pip install git+ssh://git@github.com/F5Networks/f5-icontrol-rest@v0.1.0`
+```
+
+## Configuration
+N/A
+
+## Usage
+```python
+from icontrol.session import iControlRESTSession
+icr_session = iControlRESTSession('myuser', 'mypass')
+icr_session.get(
+    'https://bigip.example.com/mgmt/tm/ltm/nat',
+    instance_name='mynat',
+    folder='Common')
+```
+
+## Documentation
+See [Documentation](http://f5-icontrol-rest-python.github.io)
+
+
+## Filing Issues
+If you find an issue we would love to hear about it.  Please let us know by
+filing an issue in this repository and tell us as much as you can about what
+you found and how you found it.
+
+## Contributing
+See [Contributing](CONTRIBUTING.md)
+
+## Build
+To make a PyPI package...
+```bash
+python setup.py sdist
+```
+
+## Test
+Before you open a pull request, your code must have passing
+[pytest](http://pytest.org) unit tests. In addition, you should include a set of
+functional tests written to use a real BIG-IP device for testing. Information on
+how to run our set of tests is included below.
+
+#### Unit Tests
+We use pytest for our unit tests
+1. If you haven't already, install the required test packages and the requirements.txt in your virtual environment.
+```shell
+$ pip install hacking pytest pytest-cov
+$ pip install -r requirements.txt
+```
+2. Run the tests and produce a coverage repor.  The `--cov-report=html` will
+create a `htmlcov/` directory that you can view in your browser to see the
+missing lines of code.
+```shell
+py.test --cov ./icontrol --cov-report=html
+open htmlcov/index.html
+```
+
+#### Style Checks
+We use the hacking module for our style checks (installed as part of
+step 1 in the Unit Test section).
+```shell
+flake8 ./
+```
+
+## Contact
+<f5-icontrol-rest@f5.com>
+
+## Copyright
+Copyright 2015-2016 F5 Networks Inc.
+
+## Support
+See [Support](SUPPORT.md)
+
+## License
+ 
+### Apache V2.0
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+ 
+http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ 
+### Contributor License Agreement
+Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html) to Openstack_CLA@f5.com prior to their
+code submission being included in this project.
+

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,5 @@
+Maintenance and support of the unmodified F5 code is provided only to customers
+who have an existing support contract, purchased separately subject to F5’s
+support policies available at http://www.f5.com/about/guidelines-policies/ and 
+http://askf5.com.  F5 will not provide maintenance and support services of
+modified F5 code or code that does not have an existing support contract.


### PR DESCRIPTION
@jputrino 
#### What issues does this address?
Fixes #41

#### What's this change do?
* Add the SUPPORT file
* Add the license section to the README
* Add the license section to the CONTRIBUTING

#### Where should the reviewer start?
Take a look at the Support and License sections of the CONTRIBUTING and README files

#### Any background context?
These are the things required by our discussions with legal.