### PR TITLE
Travis CI Build 1 Failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ deploy:
 notifications:
     slack:
       rooms:
-        - f5openstackdev:IbC9KXz2vGVq9jkOLCT5USYD#icontrol_rest_python
-        - f5openstackdev:IbC9KXz2vGVq9jkOLCT5USYD#build-status
+        - f5openstackdev:$SLACK_PROJECT_TOKEN
+        - f5openstackdev:$SLACK_BUILD_STATUS_TOKEN
       on_success: change
       on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 before_install:
     - git config --global user.email "OpenStack_TravisCI@f5.com"
     - git config --global user.name "Travis F5 Openstack"
-    - git fetch --depth=100
 install:
     - pip install requests hacking pytest pytest-cov
 script:

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,7 @@ Agreement <http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html>
 to Openstack\_CLA@f5.com prior to their code submission being included
 in this project.
 
-.. |Build Status| image:: https://travis-ci.com/F5Networks/f5-icontrol-rest-python.svg?token=2gRRgdSNRf2z9jAftSpV
-   :target: https://travis-ci.com/F5Networks/f5-icontrol-rest-python
+.. |Build Status| image:: https://travis-ci.org/F5Networks/f5-icontrol-rest-python.svg?branch=develop
+    :target: https://travis-ci.org/F5Networks/f5-icontrol-rest-python
 .. |Documentation Status| image:: https://readthedocs.org/projects/icontrol/badge/?version=latest
    :target: http://icontrol.readthedocs.org/en/latest/?badge=latest


### PR DESCRIPTION
@jlongstaf 

Issues:
Fixes #49

Problem:
Travis build failure and missing build image after public repo
change.

Analysis:
* Removed the git fetch command because we are doing depth above
* Corrected link to use travis-ci.org

Tests: