### PR TITLE
update CLA landing page URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,5 +79,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
  
 ### Contributor License Agreement
-Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html) to Openstack_CLA@f5.com prior to their
+Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html) to Openstack_CLA@f5.com prior to their
 code submission being included in this project.

--- a/README.rst
+++ b/README.rst
@@ -148,10 +148,7 @@ Contributor License Agreement
 `````````````````````````````
 
 Individuals or business entities who contribute to this project must
-have completed and submitted the `F5 Contributor License
-Agreement <http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html>`__
-to Openstack\_CLA@f5.com prior to their code submission being included
-in this project.
+have completed and submitted the `F5 Contributor License Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`__ to Openstack\_CLA@f5.com prior to their code submission being included in this project.
 
 .. |Build Status| image:: https://travis-ci.org/F5Networks/f5-icontrol-rest-python.svg?branch=develop
     :target: https://travis-ci.org/F5Networks/f5-icontrol-rest-python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,9 +71,5 @@ limitations under the License.
 
 Contributor License Agreement
 +++++++++++++++++++++++++++++
-Individuals or business entities who contribute to this project must have
-completed and submitted the
-`F5 Contributor License Agreement <http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html>`_
-to Openstack_CLA@f5.com prior to their code submission being included in this
-project.
+Individuals or business entities who contribute to this project must have completed and submitted the `F5 Contributor License Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html>`_ to Openstack_CLA@f5.com prior to their code submission being included in this project.
 


### PR DESCRIPTION
Fixes #61 

@swormke 

#### What's this change do?
I changed the URL for the CLA landing page from the github.io one to the new read the docs URL.

#### Where should the reviewer start?
Review the changes below.

#### Any background context?