### PR TITLE
Leverage logging to pass messages to handlers

### DIFF
--- a/icontrol/test/test_session.py
+++ b/icontrol/test/test_session.py
@@ -12,8 +12,11 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import logging
 import mock
+from pprint import pprint as pp
 import pytest
+from requests import ConnectionError
 
 from icontrol import session
 
@@ -267,3 +270,12 @@ def test_wrapped_put_success_with_data(iCRS, uparts):
     assert iCRS.session.put.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN',
                   data={'b': 2})
+
+
+def test_set_log_level(uparts):
+    pp("start test_set_log_level")
+    real_iCRS = session.iControlRESTSession('admin', 'admin',
+                                            loglevel=logging.DEBUG)
+    with pytest.raises(ConnectionError):
+        real_iCRS.put(uparts['base_uri'], partition='AFN', name='AIN',
+                      data={'b': 2}, uri_as_parts=True)


### PR DESCRIPTION
Issues:
Fixes #71

Problem: I wasn't using logging properly.

Analysis: This changes has the following features:

messages are submitted to the default handler
the logger is set to level WARNING (by default)
the logger can be set to other levels using the 'loglevel' kwarg of the
iControlRESTSession class
pre- and post- logs are level debug

Tests: test_set_log_level