### PR TITLE
Add token-based authentication for non-admin users

### DIFF
--- a/docs/apidocs/icontrol.rst
+++ b/docs/apidocs/icontrol.rst
@@ -4,6 +4,25 @@ icontrol package
 Submodules
 ----------
 
+
+icontrol.authtoken module
+--------------------------
+
+.. automodule:: icontrol.authtoken
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+icontrol.exceptions module
+--------------------------
+
+.. automodule:: icontrol.exceptions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 icontrol.session module
 -----------------------
 

--- a/icontrol/authtoken.py
+++ b/icontrol/authtoken.py
@@ -1,0 +1,137 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""A requests-compatible system for BIG-IP token-based authentication.
+
+BIG-IP only allows users with the Administrator role to authenticate to
+iControl using HTTP Basic auth.  Non-Administrator users can use the
+token-based authentication scheme described at:
+
+  https://devcentral.f5.com/wiki/icontrol.authentication_with_the_f5_rest_api.ashx
+
+Use this module with requests to automatically get a new token, and attach
+:class:`requests.Session` object, so that it is used to authenticate future
+requests.
+
+This can be enabled in the iControlRESTSession by passing a "token=True"
+argument:
+
+   iCRSession = iControlRESTSession('bob', 'secret', token=True)
+"""
+
+from icontrol.exceptions import iControlUnexpectedHTTPError
+from icontrol.exceptions import InvalidScheme
+import requests
+from requests.auth import AuthBase
+from requests.auth import HTTPBasicAuth
+import time
+import urlparse
+
+
+class iControlRESTTokenAuth(AuthBase):
+    def __init__(self, username, password, login_provider_name='tmos'):
+        self.username = username
+        self.password = password
+        self.login_provider_name = login_provider_name
+        self.token = None
+        self.expiration = None
+        self.attempts = 0
+        # We don't actually do auth at this point because we don't have a
+        # hostname to authenticate to.
+
+    def token_valid(self):
+        if not self.token:
+            return False
+        if self.expiration and time.time() > self.expiration:
+            return False
+        return True
+
+    def get_new_token(self, netloc):
+        login_body = {
+            'username': self.username,
+            'password': self.password,
+            'loginProviderName': self.login_provider_name,
+        }
+        login_url = "https://%s/mgmt/shared/authn/login" % (netloc)
+        req_start_time = time.time()
+        response = requests.post(login_url,
+                                 json=login_body,
+                                 verify=False,
+                                 auth=HTTPBasicAuth(self.username,
+                                                    self.password))
+        self.attempts += 1
+        if not response.ok or not hasattr(response, "json"):
+            error_message = '%s Unexpected Error: %s for uri: %s\nText: %r' %\
+                            (response.status_code,
+                             response.reason,
+                             response.url,
+                             response.text)
+            raise iControlUnexpectedHTTPError(error_message,
+                                              response=response)
+        respJson = response.json()
+
+        expiration_bigip, created_bigip = None, None
+        try:
+            self.token = respJson['token']['token']
+            expiration_bigip = int(respJson['token']['expirationMicros']) / \
+                1000000.0
+            created_bigip = int(respJson['token']['lastUpdateMicros']) / \
+                1000000.0
+        except KeyError:
+            error_message = \
+                '%s Unparseable Response: %s for uri: %s\nText: %r' %\
+                (response.status_code,
+                 response.reason,
+                 response.url,
+                 response.text)
+            raise iControlUnexpectedHTTPError(error_message,
+                                              response=response)
+
+        # Set our token expiration time.
+        # The expirationMicros field is when BIG-IP will expire the token
+        # relative to its local clock.  To avoid issues caused by incorrect
+        # clocks or network latency, we'll compute an expiration time that is
+        # referenced to our local clock, and expires slightly before the token
+        # should actually expire on BIG-IP
+
+        # Reference to our clock: compute for how long this token is valid as
+        # the difference between when it expires and when it was created,
+        # according to BIG-IP.
+        if expiration_bigip < created_bigip:
+            error_message = \
+                '%s Token already expired: %s for uri: %s\nText: %r' % \
+                (response.status_code,
+                 time.ctime(expiration_bigip),
+                 response.url,
+                 response.text)
+            raise iControlUnexpectedHTTPError(error_message,
+                                              response=response)
+        valid_duration = expiration_bigip - created_bigip
+
+        # Assign new expiration time that is 1 minute earlier than BIG-IP's
+        # expiration time, as long as that would still be at least a minute in
+        # the future.  This should account for clock skew between us and
+        # BIG-IP.  By default tokens last for 60 minutes so getting one every
+        # 59 minutes instead of 60 is harmless.
+        if valid_duration > 120.0:
+            valid_duration -= 60.0
+        self.expiration = req_start_time + valid_duration
+
+    def __call__(self, r):
+        if not self.token_valid():
+            scheme, netloc, path, _, _ = urlparse.urlsplit(r.url)
+            if scheme != "https":
+                raise InvalidScheme(scheme)
+            self.get_new_token(netloc)
+        r.headers['X-F5-Auth-Token'] = self.token
+        return r

--- a/icontrol/exceptions.py
+++ b/icontrol/exceptions.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+"""Exceptions that can be emitted by the icontrol package."""
 
 from requests import HTTPError
 

--- a/icontrol/exceptions.py
+++ b/icontrol/exceptions.py
@@ -1,0 +1,52 @@
+# Copyright 2015-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from requests import HTTPError
+
+
+class iControlUnexpectedHTTPError(HTTPError):
+    # The Status Code was in the range 207-399
+    pass
+
+
+class BigIPInvalidURL(Exception):
+    # Some component to be incorporated into the uri is illegal
+    pass
+
+
+class InvalidScheme(BigIPInvalidURL):
+    # The only acceptable scheme is https
+    pass
+
+
+class InvalidBigIP_ICRURI(BigIPInvalidURL):
+    # This must contain the servername/address and /mgmt/tm/
+    pass
+
+
+class InvalidPrefixCollection(BigIPInvalidURL):
+    # Must not start with '/' because it's relative to the icr_uri
+    # must end with a '/' since there may be names or suffixes
+    # following and they are relative, to the prefix
+    pass
+
+
+class InvalidInstanceNameOrFolder(BigIPInvalidURL):
+    # instance names and partitions must not contain the '~' or '/' chars
+    pass
+
+
+class InvalidSuffixCollection(BigIPInvalidURL):
+    # must start with a '/' since there may be a partition or name before it
+    pass

--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -58,50 +58,20 @@ against the BigIP REST Server, by pre- and post- processing the above methods.
 """
 
 import functools
+from icontrol.exceptions import iControlUnexpectedHTTPError
+from icontrol.exceptions import InvalidBigIP_ICRURI
+from icontrol.exceptions import InvalidInstanceNameOrFolder
+from icontrol.exceptions import InvalidPrefixCollection
+from icontrol.exceptions import InvalidScheme
+from icontrol.exceptions import InvalidSuffixCollection
 import logging
 import requests
 import urlparse
 
+
 # Configure logging defaults
 format_str = '%(levelname)s %(asctime)s %(message)s'
 logging.basicConfig(format=format_str)
-
-
-class iControlUnexpectedHTTPError(requests.HTTPError):
-    # The Status Code was in the range 207-399
-    pass
-
-
-class BigIPInvalidURL(Exception):
-    # Some component to be incorporated into the uri is illegal
-    pass
-
-
-class InvalidScheme(BigIPInvalidURL):
-    # The only acceptable scheme is https
-    pass
-
-
-class InvalidBigIP_ICRURI(BigIPInvalidURL):
-    # This must contain the servername/address and /mgmt/tm/
-    pass
-
-
-class InvalidPrefixCollection(BigIPInvalidURL):
-    # Must not start with '/' because it's relative to the icr_uri
-    # must end with a '/' since there may be names or suffixes
-    # following and they are relative, to the prefix
-    pass
-
-
-class InvalidInstanceNameOrFolder(BigIPInvalidURL):
-    # instance names and partitions must not contain the '~' or '/' chars
-    pass
-
-
-class InvalidSuffixCollection(BigIPInvalidURL):
-    # must start with a '/' since there may be a partition or name before it
-    pass
 
 
 def _validate_icruri(base_uri):

--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -243,6 +243,10 @@ class iControlRESTSession(object):
     Objects instantiated from this class provide an HTTP 1.1 style session, via
     the :class:`requests.Session` object, and HTTP-methods that are specialized
     to the BigIP-RESTServer interface.
+
+    Pass ``token=True`` in ``**kwargs`` to use token-based authentication.
+    This is required for users that do not have the Administrator role on
+    BigIP.
     """
     def __init__(self, username, password, **kwargs):
         """Instantiation associated with requests.Session via composition.

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,6 +1,7 @@
 requests >= 2.9.1
 
 sphinx >= 1.3.4
+sphinx_rtd_theme >= 0.1.9
 
 # Test Requirements
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests >= 2.9.1
 pytest
 pytest-coverage
 hacking
+mock

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -26,6 +26,14 @@ def pytest_addoption(parser):
     parser.addoption("--password", action="store", help="BIG-IP REST password",
                      default="admin")
 
+    # These are optional; if not specified, tests skip.
+    parser.addoption("--nonadmin-username", action="store",
+                     help="BIG-IP REST username for non-admin user",
+                     default=None)
+    parser.addoption("--nonadmin-password", action="store",
+                     help="BIG-IP REST password for non-admin user",
+                     default=None)
+
 
 def pytest_generate_tests(metafunc):
     assert metafunc.config.option.bigip
@@ -44,6 +52,16 @@ def opt_username(request):
 @pytest.fixture
 def opt_password(request):
     return request.config.getoption("--password")
+
+
+@pytest.fixture
+def opt_nonadmin_username(request):
+    return request.config.getoption("--nonadmin-username")
+
+
+@pytest.fixture
+def opt_nonadmin_password(request):
+    return request.config.getoption("--nonadmin-password")
 
 
 @pytest.fixture

--- a/test/functional/test_session.py
+++ b/test/functional/test_session.py
@@ -25,6 +25,7 @@ from requests.exceptions import HTTPError
 
 from pprint import pprint as pp
 import pytest
+import time
 
 nat_data = {
     'name': 'foo',
@@ -57,6 +58,15 @@ def invalid_credentials(user, password, url):
         icr.get(url)
     return (err.value.response.status_code == 401 and
             '401 Client Error: F5 Authorization Required' in err.value.message)
+
+
+def invalid_token_credentials(user, password, url):
+    '''Reusable test to make sure that we get 401 for invalid token creds '''
+    icr = iControlRESTSession(user, password, token=True)
+    with pytest.raises(HTTPError) as err:
+        icr.get(url)
+    return (err.value.response.status_code == 401 and
+            'Authentication required!' in err.value.message)
 
 
 def test_get(ICR, GET_URL):
@@ -215,3 +225,91 @@ def test_invalid_password(opt_username, GET_URL):
     Pass: Returns 401 with authorization required message
     '''
     invalid_credentials(opt_username, 'fakepassword', GET_URL)
+
+
+def test_token_auth(opt_username, opt_password, GET_URL):
+    icr = iControlRESTSession(opt_username, opt_password, token=True)
+    response = icr.get(GET_URL)
+    assert response.status_code == 200
+
+
+def test_token_auth_twice(opt_username, opt_password, GET_URL):
+    icr = iControlRESTSession(opt_username, opt_password, token=True)
+    assert icr.session.auth.attempts == 0
+    response = icr.get(GET_URL)
+    assert response.status_code == 200
+    assert icr.session.auth.attempts == 1
+    response = icr.get(GET_URL)
+    assert response.status_code == 200
+    # This token should still be valid, so we should reuse it.
+    assert icr.session.auth.attempts == 1
+
+
+def test_token_auth_expired(opt_username, opt_password, GET_URL):
+    icr = iControlRESTSession(opt_username, opt_password, token=True)
+    assert icr.session.auth.attempts == 0
+    response = icr.get(GET_URL)
+    assert response.status_code == 200
+    assert icr.session.auth.attempts == 1
+    assert icr.session.auth.expiration >= time.time()
+
+    # Artificially expire the token
+    icr.session.auth.expiration = time.time() - 1.0
+
+    # Since token is expired, we should get a new one.
+    response = icr.get(GET_URL)
+    assert response.status_code == 200
+    assert icr.session.auth.attempts == 2
+
+
+def test_token_invalid_user(opt_password, GET_URL):
+    invalid_token_credentials('fakeuser', opt_password, GET_URL)
+
+
+def test_token_invalid_password(opt_username, GET_URL):
+    invalid_token_credentials(opt_username, 'fakepassword', GET_URL)
+
+
+# You must configure a user that has a non-admin role in a partition for
+# test_nonadmin tests to be effective.  For instance:
+#
+# auth user bob {
+#    description bob
+#    encrypted-password $6$LsSnHp7J$AIJ2IC8kS.YDrrn/sH6BsxQ...
+#    partition Common
+#    partition-access {
+#        bobspartition {
+#            role operator
+#        }
+#    }
+#    shell tmsh
+# }
+#
+# Then instantiate with --nonadmin-username=bob --nonadmin-password=changeme
+def test_nonadmin_token_auth(opt_nonadmin_username, opt_nonadmin_password,
+                             GET_URL):
+    if not opt_nonadmin_username or not opt_nonadmin_password:
+        pytest.skip("No non-admin username/password configured")
+    icr = iControlRESTSession(opt_nonadmin_username,
+                              opt_nonadmin_password,
+                              token=True)
+    response = icr.get(GET_URL)
+    assert response.status_code == 200
+
+
+def test_nonadmin_token_auth_invalid_password(opt_nonadmin_username,
+                                              GET_URL):
+    if not opt_nonadmin_username:
+        pytest.skip("No non-admin username/password configured")
+    invalid_token_credentials(opt_nonadmin_username,
+                              'fakepassword',
+                              GET_URL)
+
+
+def test_nonadmin_token_auth_invalid_username(opt_nonadmin_password,
+                                              GET_URL):
+    if not opt_nonadmin_password:
+        pytest.skip("No non-admin username/password configured")
+    invalid_token_credentials('fakeuser',
+                              opt_nonadmin_password,
+                              GET_URL)


### PR DESCRIPTION
Users that do not have the administrator role cannot use basic HTTP authentication for BIG-IP iControl REST.  They must instead get an authentication token that they provide with each request, as described here:
    
https://devcentral.f5.com/wiki/icontrol.authentication_with_the_f5_rest_api.ashx

This pull request adds support for that feature.  It also adds 8 new tests of the functionality.  3 require a non-admin user to be configured on the BIG-IP; they skip if the caller doesn't pass "--nonadmin-username" and "--nonadmin-password".  They pass for me:

```
$ py.test --pdb ./ --bigip=1.2.3.4 --username=admin --password=XXXX
=================================================== test session starts ====================================================
platform darwin -- Python 2.7.8, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /Users/andrew/velcro/f5-icontrol-rest-python, inifile:
plugins: cov-2.2.1
collected 20 items

test_session.py .................sss

========================================== 17 passed, 3 skipped in 12.46 seconds ===========================================
$ py.test --pdb ./ --bigip=1.2.3.4 --username=admin --password=XXXX --nonadmin-username=bob --nonadmin-password=YYYY
=================================================== test session starts ====================================================
platform darwin -- Python 2.7.8, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /Users/andrew/velcro/f5-icontrol-rest-python, inifile:
plugins: cov-2.2.1
collected 20 items

test_session.py ....................

================================================ 20 passed in 17.21 seconds ================================================
```