### PR TITLE
Support is needed for requests version < 2.9.1

### DIFF
--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -280,7 +280,7 @@ class iControlRESTSession(object):
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
         requests_version = requests.__version__
-        if StrictVersion(requests_version) >= '2.9.1':
+        if StrictVersion(requests_version) < '2.9.1':
             requests.packages.urllib3.disable_warnings()
 
         # Compose with a Session obj

--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -57,6 +57,7 @@ against the BigIP REST Server, by pre- and post- processing the above methods.
 
 """
 
+from distutils.version import StrictVersion
 import functools
 import logging
 import requests
@@ -278,7 +279,9 @@ class iControlRESTSession(object):
         timeout = kwargs.pop('timeout', 30)
         if kwargs:
             raise TypeError('Unexpected **kwargs: %r' % kwargs)
-        requests.packages.urllib3.disable_warnings()
+        requests_version = requests.__version__
+        if StrictVersion(requests_version) >= '2.9.1':
+            requests.packages.urllib3.disable_warnings()
 
         # Compose with a Session obj
         self.session = requests.Session()

--- a/icontrol/test/test_session.py
+++ b/icontrol/test/test_session.py
@@ -267,3 +267,24 @@ def test_wrapped_put_success_with_data(iCRS, uparts):
     assert iCRS.session.put.call_args ==\
         mock.call('https://0.0.0.0/mgmt/tm/root/RESTiface/~AFN~AIN',
                   data={'b': 2})
+
+
+def test___init__with_newer_requests_pkg():
+    with mock.patch('icontrol.session.requests') as mock_requests:
+        mock_requests.__version__ = '2.9.9'
+        session.iControlRESTSession('test_name', 'test_pw')
+        assert mock_requests.packages.urllib3.disable_warnings.called is True
+
+
+def test___init__with_older_requests_pkg():
+    with mock.patch('icontrol.session.requests') as mock_requests:
+        mock_requests.__version__ = '2.1.1'
+        session.iControlRESTSession('test_name', 'test_pw')
+        assert mock_requests.packages.urllib3.disable_warnings.called is False
+
+
+def test___init__with_2_9_1_requests_pkg():
+    with mock.patch('icontrol.session.requests') as mock_requests:
+        mock_requests.__version__ = '2.9.1'
+        session.iControlRESTSession('test_name', 'test_pw')
+        assert mock_requests.packages.urllib3.disable_warnings.called is True

--- a/icontrol/test/test_session.py
+++ b/icontrol/test/test_session.py
@@ -273,18 +273,18 @@ def test___init__with_newer_requests_pkg():
     with mock.patch('icontrol.session.requests') as mock_requests:
         mock_requests.__version__ = '2.9.9'
         session.iControlRESTSession('test_name', 'test_pw')
-        assert mock_requests.packages.urllib3.disable_warnings.called is True
+        assert mock_requests.packages.urllib3.disable_warnings.called is False
 
 
 def test___init__with_older_requests_pkg():
     with mock.patch('icontrol.session.requests') as mock_requests:
         mock_requests.__version__ = '2.1.1'
         session.iControlRESTSession('test_name', 'test_pw')
-        assert mock_requests.packages.urllib3.disable_warnings.called is False
+        assert mock_requests.packages.urllib3.disable_warnings.called is True
 
 
 def test___init__with_2_9_1_requests_pkg():
     with mock.patch('icontrol.session.requests') as mock_requests:
         mock_requests.__version__ = '2.9.1'
         session.iControlRESTSession('test_name', 'test_pw')
-        assert mock_requests.packages.urllib3.disable_warnings.called is True
+        assert mock_requests.packages.urllib3.disable_warnings.called is False

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='f5-icontrol-rest',
       author_email='f5-icontrol-rest-python@f5.com',
       url='https://github.com/F5Networks/f5-icontrol-rest-python',
       keywords=['F5', 'icontrol', 'rest', 'api', 'bigip'],
-      install_requires=['requests>=2.9.1'],
+      install_requires=['requests'],
       py_modules=[
           'icontrol.session',
       ],


### PR DESCRIPTION
@zancas 

Issues:
Fixes #92

Problem:
We need to support older versions of requests (older than 2.9.1) to be
compliant with some Openstack clients that use older versions of
requests.

Analysis:
Inspecting the requests version and suppressing
requests.packages.urllib3.disable_warnings() call if the current version
of requests is less than 2.9.1.

Tests:
All unit tests and functional tests pass
