### PR TITLE
Moves the conftest.py file to the root dir

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,7 +19,7 @@ import pytest
 
 
 def pytest_addoption(parser):
-    parser.addoption("--bigip", action="store",
+    parser.addoption("--bigip", action="store", default='localhost',
                      help="BIG-IP hostname or IP address")
     parser.addoption("--username", action="store", help="BIG-IP REST username",
                      default="admin")


### PR DESCRIPTION
Issues:
Fixes #96

Problem:
When running pytest for the functional tests, if you run it from
the top-level directory, it will fail to run because it is not
found.

Analysis:
The change just relocates the file out of the functional test
directory so that it can be used in all tests

Tests:
none
