### PR TITLE
Add python 3 support while maintaining 2.7 compat

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,7 @@ def pytest_addoption(parser):
     parser.addoption("--username", action="store", help="BIG-IP REST username",
                      default="admin")
     parser.addoption("--port", action="store", help="BIG-IP port",
-                     default=443)
+                     default='443')
     parser.addoption("--password", action="store", help="BIG-IP REST password",
                      default="admin")
 

--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -61,7 +61,13 @@ from distutils.version import StrictVersion
 import functools
 import logging
 import requests
-import urlparse
+
+try:
+    # Python 3
+    from urllib.parse import urlsplit
+except ImportError:
+    # Python 2
+    from urlparse import urlsplit
 
 
 class iControlUnexpectedHTTPError(requests.HTTPError):
@@ -104,7 +110,7 @@ class InvalidSuffixCollection(BigIPInvalidURL):
 def _validate_icruri(base_uri):
     # The icr_uri should specify https, the server name/address, and the path
     # to the REST-or-tm management interface "/mgmt/tm/"
-    scheme, netloc, path, _, _ = urlparse.urlsplit(base_uri)
+    scheme, netloc, path, _, _ = urlsplit(base_uri)
     if scheme != 'https':
         raise InvalidScheme(scheme)
     if not path.startswith('/mgmt/tm/'):


### PR DESCRIPTION
Issues:
Fixes #95

Problem:
The need to support python 3 is becoming more and more pronounced.
The issue of supporting python 3 in the F5 repos should be addressed
before the code becomes too large.

Analysis:
This change adds python 3 support while continuing to support backwards
compatibility with python 2.7+

Tests:
none
