### PR TITLE
Activate python3 checking in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: python
 python:
     - "2.7"
     - "2.6"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "nightly"
 before_install:
     - git config --global user.email "OpenStack_TravisCI@f5.com"
     - git config --global user.name "Travis F5 Openstack"


### PR DESCRIPTION
Issues:
Fixes #104

Problem:
Python3 compatibility should be ready, but we are not actively
checking it for PR's.

Analysis:
This patch activates python3 checking by Travis

Tests:
none
