### PR TITLE
Adds user-agent support to the rest session object

### DIFF
--- a/icontrol/test/functional/test_session.py
+++ b/icontrol/test/functional/test_session.py
@@ -24,7 +24,9 @@ from icontrol.session import iControlRESTSession
 from requests.exceptions import HTTPError
 
 from pprint import pprint as pp
+import icontrol
 import pytest
+import requests
 import time
 
 nat_data = {
@@ -388,3 +390,29 @@ def test_nonadmin_token_auth_invalid_username(opt_nonadmin_password,
     invalid_token_credentials('fakeuser',
                               opt_nonadmin_password,
                               GET_URL)
+
+
+def test_default_headers(opt_username, opt_password):
+    '''Test a GET request to a valid url
+
+    Pass: Returns a 200 with proper json
+    '''
+    icr = iControlRESTSession(opt_username, opt_password)
+    rresult = 'python-requests/{0}'.format(requests.__version__)
+    iresult = 'f5-icontrol-rest-python/{0}'.format(icontrol.__version__)
+    assert rresult in icr.session.headers['User-Agent']
+    assert iresult in icr.session.headers['User-Agent']
+
+
+def test_specified_headers(opt_username, opt_password):
+    '''Test a GET request to a valid url
+
+    Pass: Returns a 200 with proper json
+    '''
+    agent = 'foo/1.2.3'
+    icr = iControlRESTSession(opt_username, opt_password, user_agent=agent)
+    rresult = 'python-requests/{0}'.format(requests.__version__)
+    iresult = 'f5-icontrol-rest-python/{0}'.format(icontrol.__version__)
+    assert rresult in icr.session.headers['User-Agent']
+    assert iresult in icr.session.headers['User-Agent']
+    assert agent in icr.session.headers['User-Agent']

--- a/icontrol/test/unit/test_session.py
+++ b/icontrol/test/unit/test_session.py
@@ -14,6 +14,8 @@
 
 import mock
 import pytest
+import requests
+import icontrol
 
 from icontrol import session
 
@@ -353,3 +355,23 @@ def test___init__with_2_9_1_requests_pkg():
         mock_requests.__version__ = '2.9.1'
         session.iControlRESTSession('test_name', 'test_pw')
         assert mock_requests.packages.urllib3.disable_warnings.called is False
+
+
+def test_default_user_agent():
+    rest = session.iControlRESTSession('test_name', 'test_pw')
+    rresult = 'python-requests/{0}'.format(requests.__version__)
+    iresult = 'f5-icontrol-rest-python/{0}'.format(icontrol.__version__)
+    assert rresult in rest.session.headers['User-Agent']
+    assert iresult in rest.session.headers['User-Agent']
+
+
+def test_specified_user_agent():
+    agent = 'foo/1.2.3'
+    rest = session.iControlRESTSession(
+        'test_name', 'test_pw', user_agent=agent
+    )
+    rresult = 'python-requests/{0}'.format(requests.__version__)
+    iresult = 'f5-icontrol-rest-python/{0}'.format(icontrol.__version__)
+    assert rresult in rest.session.headers['User-Agent']
+    assert iresult in rest.session.headers['User-Agent']
+    assert agent in rest.session.headers['User-Agent']


### PR DESCRIPTION
Fixes: #116

Problem:
The session object does not send any header for User-Agent, nor
does it allow you to specify your own.

Analysis:
This patch provides support for sending a User-Agent header as
well as specifying a string to append to the existing User-Agent
header

This patch provides the necessary code to be used by the f5-sdk
to expose this ability to users of the sdk

Tests:
unit
functional