### PR TITLE
Fixes #119

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,6 +28,10 @@ def pytest_addoption(parser):
     parser.addoption("--password", action="store", help="BIG-IP REST password",
                      default="admin")
 
+    parser.addoption("--release", action="store",
+                     help="TMOS version, in dotted format, eg. 12.0.0",
+                     default='11.6.0')
+
     # These are optional; if not specified, tests skip.
     parser.addoption("--nonadmin-username", action="store",
                      help="BIG-IP REST username for non-admin user",
@@ -75,6 +79,11 @@ def opt_nonadmin_password(request):
 def ICR(opt_bigip, opt_username, opt_password):
     icr = iControlRESTSession(opt_username, opt_password)
     return icr
+
+
+@pytest.fixture
+def opt_release(request):
+    return request.config.getoption("--release")
 
 
 @pytest.fixture

--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -246,7 +246,7 @@ def decorate_HTTP_verb_method(method):
         uri_as_parts = kwargs.pop('uri_as_parts', False)
         transform_name = kwargs.pop('transform_name', False)
         if uri_as_parts:
-            REST_uri = generate_bigip_uri(RIC_base_uri, partition, name,
+            REST_uri = generate_bigip_uri(RIC_base_uri, partition, identifier,
                                           sub_path, suffix,
                                           transform_name=transform_name,
                                           **kwargs)

--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -164,7 +164,7 @@ def _validate_uri_parts(
     # Apply the above validators to the correct components.
     _validate_icruri(base_uri)
     _validate_name_partition_subpath(partition)
-    if not kwargs['transform_name']:
+    if not kwargs.get('transform_name', False):
         _validate_name_partition_subpath(name)
     _validate_name_partition_subpath(sub_path)
     if suffix_collections:
@@ -199,7 +199,7 @@ def generate_bigip_uri(base_uri, partition, name, sub_path, suffix, **kwargs):
     _validate_uri_parts(base_uri, partition, name, sub_path, suffix,
                         **kwargs)
 
-    if kwargs['transform_name']:
+    if kwargs.get('transform_name', False):
         if name != '':
             name = name.replace('/', '~')
     if partition != '':

--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -110,7 +110,9 @@ def _validate_prefix_collections(prefix_collections):
 
 
 def _validate_name_partition_subpath(element):
-    # '/' and '~' are illegal characters
+    # '/' and '~' are illegal characters in most cases, however there are
+    # few exceptions (GTM Regions endpoint being one of them where the
+    # validation of name should not apply.
     if element == '':
         return True
     if '~' in element:
@@ -146,11 +148,13 @@ def _validate_suffix_collections(suffix_collections):
 
 
 def _validate_uri_parts(
-        base_uri, partition, name, sub_path, suffix_collections):
+        base_uri, partition, name, sub_path, suffix_collections,
+        **kwargs):
     # Apply the above validators to the correct components.
     _validate_icruri(base_uri)
     _validate_name_partition_subpath(partition)
-    _validate_name_partition_subpath(name)
+    if not kwargs['transform_name']:
+        _validate_name_partition_subpath(name)
     _validate_name_partition_subpath(sub_path)
     if suffix_collections:
         _validate_suffix_collections(suffix_collections)
@@ -161,7 +165,7 @@ def generate_bigip_uri(base_uri, partition, name, sub_path, suffix, **kwargs):
     '''(str, str, str) --> str
 
     This function checks the supplied elements to see if each conforms to
-    the specifiction for the appropriate part of the URI. These validations
+    the specification for the appropriate part of the URI. These validations
     are conducted by the helper function _validate_uri_parts.
     After validation the parts are assembled into a valid BigIP REST URI
     string which is then submitted with appropriate metadata.
@@ -175,8 +179,18 @@ def generate_bigip_uri(base_uri, partition, name, sub_path, suffix, **kwargs):
     >>> generate_bigip_uri('https://0.0.0.0/mgmt/tm/ltm/nat/', '', '', \
     params={'a':1}, suffix='/thwocky')
     'https://0.0.0.0/mgmt/tm/ltm/nat/thwocky'
+
+    ::Warning: There are cases where '/' and '~' characters are valid in the
+        object name. This is indicated by passing 'transform_name' boolean as
+        True, by default this is set to False.
     '''
-    _validate_uri_parts(base_uri, partition, name, sub_path, suffix)
+
+    _validate_uri_parts(base_uri, partition, name, sub_path, suffix,
+                        **kwargs)
+
+    if kwargs['transform_name']:
+        if name != '':
+            name = name.replace('/', '~')
     if partition != '':
         partition = '~' + partition
     else:
@@ -191,6 +205,7 @@ def generate_bigip_uri(base_uri, partition, name, sub_path, suffix, **kwargs):
     tilded_partition_and_instance = partition + sub_path + name
     if suffix and not tilded_partition_and_instance:
         suffix = suffix.lstrip('/')
+
     REST_uri = base_uri + tilded_partition_and_instance + suffix
     return REST_uri
 
@@ -218,9 +233,12 @@ def decorate_HTTP_verb_method(method):
         sub_path = kwargs.pop('subPath', '')
         suffix = kwargs.pop('suffix', '')
         uri_as_parts = kwargs.pop('uri_as_parts', False)
+        transform_name = kwargs.pop('transform_name', False)
         if uri_as_parts:
             REST_uri = generate_bigip_uri(RIC_base_uri, partition, name,
-                                          sub_path, suffix, **kwargs)
+                                          sub_path, suffix,
+                                          transform_name=transform_name,
+                                          **kwargs)
         else:
             REST_uri = RIC_base_uri
         pre_message = "%s WITH uri: %s AND suffix: %s AND kwargs: %s" %\

--- a/icontrol/test/functional/test_session.py
+++ b/icontrol/test/functional/test_session.py
@@ -20,6 +20,7 @@ the collection objects that are after that are correct
 i.e https://192.168.1.1/mgmt/tm/boguscollection
 '''
 
+from distutils.version import LooseVersion
 from icontrol.session import iControlRESTSession
 from requests.exceptions import HTTPError
 
@@ -312,12 +313,22 @@ def test_invalid_password(opt_username, GET_URL):
     invalid_credentials(opt_username, 'fakepassword', GET_URL)
 
 
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) == LooseVersion(
+        '11.5.4'),
+    reason='Endpoint does not exist in 11.5.4'
+)
 def test_token_auth(opt_username, opt_password, GET_URL):
     icr = iControlRESTSession(opt_username, opt_password, token=True)
     response = icr.get(GET_URL)
     assert response.status_code == 200
 
 
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) == LooseVersion(
+        '11.5.4'),
+    reason='Endpoint does not exist in 11.5.4'
+)
 def test_token_auth_twice(opt_username, opt_password, GET_URL):
     icr = iControlRESTSession(opt_username, opt_password, token=True)
     assert icr.session.auth.attempts == 0
@@ -330,6 +341,11 @@ def test_token_auth_twice(opt_username, opt_password, GET_URL):
     assert icr.session.auth.attempts == 1
 
 
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) == LooseVersion(
+        '11.5.4'),
+    reason='Endpoint does not exist in 11.5.4'
+)
 def test_token_auth_expired(opt_username, opt_password, GET_URL):
     icr = iControlRESTSession(opt_username, opt_password, token=True)
     assert icr.session.auth.attempts == 0
@@ -347,10 +363,20 @@ def test_token_auth_expired(opt_username, opt_password, GET_URL):
     assert icr.session.auth.attempts == 2
 
 
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) == LooseVersion(
+        '11.5.4'),
+    reason='Endpoint does not exist in 11.5.4'
+)
 def test_token_invalid_user(opt_password, GET_URL):
     invalid_token_credentials('fakeuser', opt_password, GET_URL)
 
 
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) == LooseVersion(
+        '11.5.4'),
+    reason='Endpoint does not exist in 11.5.4'
+)
 def test_token_invalid_password(opt_username, GET_URL):
     invalid_token_credentials(opt_username, 'fakepassword', GET_URL)
 
@@ -400,6 +426,12 @@ def test_nonadmin_token_auth_invalid_username(opt_nonadmin_password,
                               GET_URL)
 
 
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) > LooseVersion(
+        '12.0.0'),
+    reason='Issue with spaces in the name parameter has been resolved post '
+           '12.1.x, therefore another test needs running'
+)
 def test_get_special_name_11_x_12_0(request, ICR, BASE_URL):
     """Get the object with '/' characters in name
 
@@ -430,6 +462,12 @@ def test_get_special_name_11_x_12_0(request, ICR, BASE_URL):
     assert data['kind'] == 'tm:gtm:topology:topologystate'
 
 
+@pytest.mark.skipif(
+    LooseVersion(pytest.config.getoption('--release')) < LooseVersion(
+        '12.1.0'),
+    reason='Issue with paces in the name parameter has been resolved in '
+           '12.1.x and up, any lower version will fail this test otherwise'
+)
 def test_get_special_name_12_1(request, ICR, BASE_URL):
     """Get the object with '/' characters in name
 

--- a/icontrol/test/unit/test_session.py
+++ b/icontrol/test/unit/test_session.py
@@ -362,8 +362,8 @@ def test_correct_uri_transformed_nameless_and_suffixless_subpath(
     transform_name_w_subpath['suffix'] = ''
     uri = session.generate_bigip_uri(**transform_name_w_subpath)
     assert uri == 'https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER~sp'
-    
-    
+
+
 def test_correct_uri_construction_mgmt_shared(uparts_shared):
     uparts_shared['name'] = ''
     uparts_shared['suffix'] = ''
@@ -376,7 +376,6 @@ def test_correct_uri_construction_mgmt_cm(uparts_cm):
     uparts_cm['suffix'] = ''
     uri = session.generate_bigip_uri(**uparts_cm)
     assert uri == 'https://0.0.0.0/mgmt/cm/root/RESTiface/~BIGCUSTOMER'
-
 
 
 # Test exception handling

--- a/icontrol/test/unit/test_session.py
+++ b/icontrol/test/unit/test_session.py
@@ -41,7 +41,19 @@ def uparts():
                   'partition': 'BIGCUSTOMER',
                   'name': 'foobar1',
                   'sub_path': '',
-                  'suffix': '/members/m1'}
+                  'suffix': '/members/m1',
+                  'transform_name': False}
+    return parts_dict
+
+
+@pytest.fixture()
+def transform_name():
+    parts_dict = {'base_uri': 'https://0.0.0.0/mgmt/tm/root/RESTiface/',
+                  'partition': 'BIGCUSTOMER',
+                  'name': 'foobar1: 1.1.1.1/24 bar1: /Common/DC1',
+                  'sub_path': '',
+                  'suffix': '/members/m1',
+                  'transform_name': True}
     return parts_dict
 
 
@@ -51,7 +63,19 @@ def uparts_with_subpath():
                   'partition': 'BIGCUSTOMER',
                   'name': 'foobar1',
                   'sub_path': 'sp',
-                  'suffix': '/members/m1'}
+                  'suffix': '/members/m1',
+                  'transform_name': False}
+    return parts_dict
+
+
+@pytest.fixture()
+def transform_name_w_subpath():
+    parts_dict = {'base_uri': 'https://0.0.0.0/mgmt/tm/root/RESTiface/',
+                  'partition': 'BIGCUSTOMER',
+                  'name': 'foobar1: 1.1.1.1/24 bar1: /Common/DC1',
+                  'sub_path': 'sp',
+                  'suffix': '/members/m1',
+                  'transform_name': True}
     return parts_dict
 
 
@@ -217,6 +241,107 @@ def test_correct_uri_construction_nameless_and_suffixless_subpath(
     uparts_with_subpath['name'] = ''
     uparts_with_subpath['suffix'] = ''
     uri = session.generate_bigip_uri(**uparts_with_subpath)
+    assert uri == 'https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER~sp'
+
+
+def test_correct_uri_construction_partitionless_transform_name(transform_name):
+    transform_name['partition'] = ''
+    uri = session.generate_bigip_uri(**transform_name)
+    assert uri == \
+        'https://0.0.0.0/mgmt/tm/root/RESTiface/foobar1: ' \
+        '1.1.1.1~24 bar1: ~Common~DC1/members/m1'
+
+
+def test_correct_uri_transformed_partitionless_subpath(
+        transform_name_w_subpath):
+    transform_name_w_subpath['partition'] = ''
+    with pytest.raises(session.InvalidURIComponentPart) as IC:
+        session.generate_bigip_uri(**transform_name_w_subpath)
+    assert str(IC.value) == \
+        'When giving the subPath component include partition as well.'
+
+
+def test_correct_uri_transformed_nameless(transform_name):
+    transform_name['name'] = ''
+    uri = session.generate_bigip_uri(**transform_name)
+    assert uri ==\
+        "https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER/members/m1"
+
+
+def test_correct_uri_transformed_nameless_subpath(transform_name_w_subpath):
+    transform_name_w_subpath['name'] = ''
+    uri = session.generate_bigip_uri(**transform_name_w_subpath)
+    assert uri ==\
+        "https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER~sp/members/m1"
+
+
+def test_correct_uri_transformed_partitionless_and_nameless(transform_name):
+    transform_name['partition'] = ''
+    transform_name['name'] = ''
+    uri = session.generate_bigip_uri(**transform_name)
+    assert uri == "https://0.0.0.0/mgmt/tm/root/RESTiface/members/m1"
+
+
+def test_correct_uri_transformed_partitionless_and_nameless_subpath(
+        transform_name_w_subpath):
+    transform_name_w_subpath['partition'] = ''
+    transform_name_w_subpath['name'] = ''
+    with pytest.raises(session.InvalidURIComponentPart) as IC:
+        session.generate_bigip_uri(**transform_name_w_subpath)
+    assert str(IC.value) == \
+        'When giving the subPath component include partition as well.'
+
+
+def test_correct_uri_transformed_partition_name_and_suffixless(transform_name):
+    transform_name['partition'] = ''
+    transform_name['name'] = ''
+    transform_name['suffix'] = ''
+    uri = session.generate_bigip_uri(**transform_name)
+    assert uri == "https://0.0.0.0/mgmt/tm/root/RESTiface/"
+
+
+def test_correct_uri_transformed_partition_name_and_suffixless_subpath(
+        transform_name_w_subpath):
+    transform_name_w_subpath['partition'] = ''
+    transform_name_w_subpath['name'] = ''
+    transform_name_w_subpath['suffix'] = ''
+    with pytest.raises(session.InvalidURIComponentPart) as IC:
+        session.generate_bigip_uri(**transform_name_w_subpath)
+    assert str(IC.value) == \
+        'When giving the subPath component include partition as well.'
+
+
+def test_correct_uri_transformed_partitionless_and_suffixless(transform_name):
+    transform_name['partition'] = ''
+    transform_name['suffix'] = ''
+    uri = session.generate_bigip_uri(**transform_name)
+    assert uri == \
+        'https://0.0.0.0/mgmt/tm/root/RESTiface/foobar1: ' \
+        '1.1.1.1~24 bar1: ~Common~DC1'
+
+
+def test_correct_uri_transformed_partitionless_and_suffixless_subpath(
+        transform_name_w_subpath):
+    transform_name_w_subpath['partition'] = ''
+    transform_name_w_subpath['suffix'] = ''
+    with pytest.raises(session.InvalidURIComponentPart) as IC:
+        session.generate_bigip_uri(**transform_name_w_subpath)
+    assert str(IC.value) == \
+        'When giving the subPath component include partition as well.'
+
+
+def test_correct_uri_transformed_nameless_and_suffixless(transform_name):
+    transform_name['name'] = ''
+    transform_name['suffix'] = ''
+    uri = session.generate_bigip_uri(**transform_name)
+    assert uri == 'https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER'
+
+
+def test_correct_uri_transformed_nameless_and_suffixless_subpath(
+        transform_name_w_subpath):
+    transform_name_w_subpath['name'] = ''
+    transform_name_w_subpath['suffix'] = ''
+    uri = session.generate_bigip_uri(**transform_name_w_subpath)
     assert uri == 'https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER~sp'
 
 


### PR DESCRIPTION
 Problem:

_validate_suffix_collections method assumes that '\~' and '/' in elements are incorrect. This leads to issues where 'name' contains '~' or '/' on purpose.

Analysis:
This patch introduces name_transform bool (with default being False), with it set to True, the 'name' element will not be validated for the presence of '\~' and '/' characters. It will also convert all '/' in the name into '~'. To use this ability BIGIP needs to pass the argument 'name_transform' in the **kwargs when calling the iControl.

Tests:
unit