### PR TITLE
Adds detection of the UUID field as a "name" when specified

### DIFF
--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -225,12 +225,12 @@ def decorate_HTTP_verb_method(method):
     @functools.wraps(method)
     def wrapper(self, RIC_base_uri, **kwargs):
         partition = kwargs.pop('partition', '')
-        name = kwargs.pop('name', '')
         sub_path = kwargs.pop('subPath', '')
         suffix = kwargs.pop('suffix', '')
+        identifier, kwargs = _unique_resource_identifier_from_kwargs(**kwargs)
         uri_as_parts = kwargs.pop('uri_as_parts', False)
         if uri_as_parts:
-            REST_uri = generate_bigip_uri(RIC_base_uri, partition, name,
+            REST_uri = generate_bigip_uri(RIC_base_uri, partition, identifier,
                                           sub_path, suffix, **kwargs)
         else:
             REST_uri = RIC_base_uri
@@ -254,6 +254,46 @@ def decorate_HTTP_verb_method(method):
             raise iControlUnexpectedHTTPError(error_message, response=response)
         return response
     return wrapper
+
+
+def _unique_resource_identifier_from_kwargs(**kwargs):
+    """Chooses an identifier given different choices
+
+    The unique identifier in BIG-IP's REST API at the time of this writing
+    is called 'name'. This is in contrast to the unique identifier that is
+    used by iWorkflow and BIG-IQ which at some times is 'name' and other
+    times is 'uuid'.
+
+    For example, in iWorkflow, there consider this URI
+
+      * https://10.2.2.3/mgmt/cm/cloud/tenants/{0}/services/iapp
+
+    Then consider this iWorkflow URI
+
+      * https://localhost/mgmt/cm/cloud/connectors/local/{0}
+
+    In the first example, the identifier, {0}, is what we would normally
+    consider a name. For example, "tenant1". In the second example though,
+    the value is expected to be what we would normally consider to be a
+    UUID. For example, '244bd478-374e-4eb2-8c73-6e46d7112604'.
+
+    This method only tries to rectify the problem of which to use.
+
+    I believe there might be some change that the two can appear together,
+    although I have not yet experienced it. If it is possible, I believe it
+    would happen in BIG-IQ/iWorkflow land where the UUID and Name both have
+    significance. That's why I deliberately prefer the UUID when it exists
+    in the parameters sent to the URL.
+
+    :param kwargs:
+    :return:
+    """
+    name = kwargs.pop('name', '')
+    uuid = kwargs.pop('uuid', '')
+    if uuid:
+        return uuid, kwargs
+    else:
+        return name, kwargs
 
 
 class iControlRESTSession(object):


### PR DESCRIPTION
both APIs like BIG-IQ that use it as the unique identifier

Problem:
BIG-IP uses names everywhere, but BIG-IQ and iWorkflow decided to
do something completely different and use UUIDs for some places and
names for some other places. Regardless, the value is still name-ish
it;s just that its called something different and needs to be treated
as a "name" in our terminology when it is provided

Analysis:
this patch adds a helper method that attempts to deduce the correct
unique identifier based on the keyword that is passed

Tests: