### PR TITLE
Fixes tox and fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -105,5 +105,5 @@ def FAKE_URL(opt_bigip, opt_port):
 
 
 @pytest.fixture
-def BASE_URL(opt_bigip):
-    return 'https://' + opt_bigip + '/mgmt/tm/'
+def BASE_URL(opt_bigip, opt_port):
+    return 'https://' + opt_bigip + ':' + opt_port + '/mgmt/tm/'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{26,27,35}-functional
+    py{26,27,35}-bip-v{11.5.4,11.6.0,11.6.1,12.0.0,12.1.0,12.1.1}
     py{26,27,35}-unit
     default-unit
     default-flake
@@ -15,7 +15,12 @@ basepython =
 deps =
     -rrequirements.test.txt
 commands =
-    py{26,27,35}-functional: py.test --bigip localhost --port 10443 -s -vv {posargs}
+    py{26,27,35}-bip-v11.5.4: py.test --bigip localhost --port 10443 -s -vv --release 11.5.4 {posargs}
+    py{26,27,35}-bip-v11.6.0: py.test --bigip localhost --port 10443 -s -vv --release 11.6.0 {posargs}
+    py{26,27,35}-bip-v11.6.1: py.test --bigip localhost --port 10443 -s -vv --release 11.6.1 {posargs}
+    py{26,27,35}-bip-v12.0.0: py.test --bigip localhost --port 10443 -s -vv --release 12.0.0 {posargs}
+    py{26,27,35}-bip-v12.1.0: py.test --bigip localhost --port 10443 -s -vv --release 12.1.0 {posargs}
+    py{26,27,35}-bip-v12.1.1: py.test --bigip localhost --port 10443 -s -vv --release 12.1.1 {posargs}
     py{26,27,35}-unit: py.test -k "not /functional/" -vv --cov {posargs}
     default-unit: py.test -k "not /functional/" -vv --cov {posargs}
     default-flake: flake8


### PR DESCRIPTION
Problem:
Tox did not include release params and BASE_URL fixture was not
specifying the port

Analysis:
This patch fixes those problems

Tests: