### PR TITLE
Adds new auth_provider method

### DIFF
--- a/icontrol/test/unit/test_session.py
+++ b/icontrol/test/unit/test_session.py
@@ -495,27 +495,6 @@ def test_wrapped_put_success_with_data(iCRS, uparts):
                   data={'b': 2})
 
 
-def test___init__with_newer_requests_pkg():
-    with mock.patch('icontrol.session.requests') as mock_requests:
-        mock_requests.__version__ = '2.9.9'
-        session.iControlRESTSession('test_name', 'test_pw')
-        assert mock_requests.packages.urllib3.disable_warnings.called is False
-
-
-def test___init__with_older_requests_pkg():
-    with mock.patch('icontrol.session.requests') as mock_requests:
-        mock_requests.__version__ = '2.1.1'
-        session.iControlRESTSession('test_name', 'test_pw')
-        assert mock_requests.packages.urllib3.disable_warnings.called is True
-
-
-def test___init__with_2_9_1_requests_pkg():
-    with mock.patch('icontrol.session.requests') as mock_requests:
-        mock_requests.__version__ = '2.9.1'
-        session.iControlRESTSession('test_name', 'test_pw')
-        assert mock_requests.packages.urllib3.disable_warnings.called is False
-
-
 def test___init__user_agent():
     icrs = session.iControlRESTSession('admin', 'admin')
     assert UA in icrs.session.headers['User-Agent']


### PR DESCRIPTION
This new method is required by BIG-IQ because it forces you to specify
the auth provider when you auth a user. BIG-IP also does this, but in
the past we covered that up with the "token=*" argument. This is actually
an incorrect abstraction.

Instead, this auth_provider method is the correct way. It can accept
strings such as "local" (for IQ), "tmos" (for IP), and "default" for
both IQ and IP. There is also the ability to provide custom auth
providers that can be created in IQ.

We do not remove the old method. Instead, we prefer the new method over
the old method. If the old method is used, it will still work. If both are attempted
to be used, the new method will be used.