### PR TITLE
Removes urllib3 dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(name='f5-icontrol-rest',
       author_email='f5-icontrol-rest-python@f5.com',
       url='https://github.com/F5Networks/f5-icontrol-rest-python',
       keywords=['F5', 'icontrol', 'rest', 'api', 'bigip'],
-      install_requires=['requests >= 2.5.0, < 3', 'urllib3'],
+      install_requires=['requests >= 2.5.0, < 3'],
       py_modules=[
           'icontrol.session',
       ],


### PR DESCRIPTION
This dep is already a part of requests, so including it a second
time can cause installation to fail if requests puts a limit on
the version of urllib3 and we dont.