### PR TITLE
Clean up RPM production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,9 @@ htmlcov/*
 # Translations
 *.mo
 
+# Emacs files
+*~
+*\#*
+
 # Locally built RPMS
 rpms

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ htmlcov/*
 
 # Translations
 *.mo
+
+# Locally built RPMS
+rpms

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,8 @@ htmlcov/*
 *~
 *\#*
 
+# Vim files
+*.swp
+
 # Locally built RPMS
 rpms

--- a/f5-icontrol-rest-dist/Docker/redhat/6/build-rpms.sh
+++ b/f5-icontrol-rest-dist/Docker/redhat/6/build-rpms.sh
@@ -1,12 +1,38 @@
 #!/bin/bash -ex
 
-SRC_DIR=$1
+if [ $# -eq 1 ]; then
+    SRC_DIR=$1
+elif [ $# -eq 0 ]; then
+    SCRIPTNAME="`readlink --canonicalize $0`"
+    SRC_DIR="`dirname "$SCRIPTNAME"`/../../../.."
+    SRC_DIR="`readlink --canonicalize $SRC_DIR`"
+else
+    echo "Error: Cound not deduce SRC_DIR, exiting" >&2
+fi
+
 PKG_NAME=f5-icontrol-rest
 DIST_DIR="${PKG_NAME}-dist"
 RPMBUILD_DIR="rpmbuild"
-OS_VERSION=6
-
 DEST_DIR="${SRC_DIR}/${DIST_DIR}"
+
+# Deduce the DIST name from "rpm --showrc"
+getdist() {
+    rpm --showrc | while read arg1 arg2 arg3; do
+	case $arg1 in
+	    -[1-9]*:)
+		#echo found valid arg1: arg2: $arg2, arg3: $arg3
+		case $arg2 in
+		    dist)
+			#echo found valid arg: arg3: $arg3
+			#echo DIST=$arg3
+			    echo $arg3
+			    ;;
+		esac
+	esac
+    done
+}
+DIST="`getdist`"
+DISTDIR="`echo $DIST | tr -d '.'`"
 
 echo "Building ${PKG_NAME} RPM packages..."
 buildroot=$(mktemp -d /tmp/${PKG_NAME}.XXXXX)
@@ -14,24 +40,21 @@ buildroot=$(mktemp -d /tmp/${PKG_NAME}.XXXXX)
 cp -R $SRC_DIR/* ${buildroot}
 
 pushd ${buildroot}
-python setup.py build bdist_rpm --rpm-base rpmbuild
+python setup.py build bdist_rpm --rpm-base rpmbuild --release=1$DIST
 
 echo "%_topdir ${buildroot}/rpmbuild" > ~/.rpmmacros
 
-python setup.py bdist_rpm --spec-only --dist-dir rpmbuild/SPECS
+python setup.py bdist_rpm --spec-only --dist-dir rpmbuild/SPECS --release=1$DIST
 
 rpmbuild -ba rpmbuild/SPECS/${PKG_NAME}.spec
 
-mkdir -p ${DEST_DIR}/rpms/build
-
-for pkg in $(ls rpmbuild/RPMS/noarch/*.rpm); do
-  if [[ $pkg =~ ".noarch." ]]; then
-    mv $pkg ${pkg%%.noarch.rpm}.el${OS_VERSION}.noarch.rpm
-  fi
-done
-cp -R rpmbuild/RPMS/noarch/*.rpm ${DEST_DIR}/rpms/build
+# Use DIST specific subdirectories
+install -d "${DEST_DIR}/rpms/build/$DISTDIR/RPMS"
+install rpmbuild/RPMS/*/*.rpm "${DEST_DIR}/rpms/build/$DISTDIR/RPMS/"
+install -d "${DEST_DIR}/rpms/build/$DISTDIR/SRPMS"
+install rpmbuild/SRPMS/*.rpm "${DEST_DIR}/rpms/build/$DISTDIR/SRPMS/"
 
 popd
 
-rm -rf ${buildroot}
+#rm -rf ${buildroot}
 

--- a/f5-icontrol-rest-dist/Docker/redhat/7/build-rpms.sh
+++ b/f5-icontrol-rest-dist/Docker/redhat/7/build-rpms.sh
@@ -1,12 +1,38 @@
 #!/bin/bash -ex
 
-SRC_DIR=$1
+if [ $# -eq 1 ]; then
+    SRC_DIR=$1
+elif [ $# -eq 0 ]; then
+    SCRIPTNAME="`readlink --canonicalize $0`"
+    SRC_DIR="`dirname "$SCRIPTNAME"`/../../../.."
+    SRC_DIR="`readlink --canonicalize $SRC_DIR`"
+else
+    echo "Error: Cound not deduce SRC_DIR, exiting" >&2
+fi
+
 PKG_NAME=f5-icontrol-rest
 DIST_DIR="${PKG_NAME}-dist"
 RPMBUILD_DIR="rpmbuild"
-OS_VERSION=7
-
 DEST_DIR="${SRC_DIR}/${DIST_DIR}"
+
+# Deduce the DIST name from "rpm --showrc"
+getdist() {
+    rpm --showrc | while read arg1 arg2 arg3; do
+	case $arg1 in
+	    -[1-9]*:)
+		#echo found valid arg1: arg2: $arg2, arg3: $arg3
+		case $arg2 in
+		    dist)
+			#echo found valid arg: arg3: $arg3
+			#echo DIST=$arg3
+			    echo $arg3
+			    ;;
+		esac
+	esac
+    done
+}
+DIST="`getdist`"
+DISTDIR="`echo $DIST | tr -d '.'`"
 
 echo "Building ${PKG_NAME} RPM packages..."
 buildroot=$(mktemp -d /tmp/${PKG_NAME}.XXXXX)
@@ -14,24 +40,21 @@ buildroot=$(mktemp -d /tmp/${PKG_NAME}.XXXXX)
 cp -R $SRC_DIR/* ${buildroot}
 
 pushd ${buildroot}
-python setup.py build bdist_rpm --rpm-base rpmbuild
+python setup.py build bdist_rpm --rpm-base rpmbuild --release=1$DIST
 
 echo "%_topdir ${buildroot}/rpmbuild" > ~/.rpmmacros
 
-python setup.py bdist_rpm --spec-only --dist-dir rpmbuild/SPECS
+python setup.py bdist_rpm --spec-only --dist-dir rpmbuild/SPECS --release=1$DIST
 
 rpmbuild -ba rpmbuild/SPECS/${PKG_NAME}.spec
 
-mkdir -p ${DEST_DIR}/rpms/build
-
-for pkg in $(ls rpmbuild/RPMS/noarch/*.rpm); do
-  if [[ $pkg =~ ".noarch." ]]; then
-    mv $pkg ${pkg%%.noarch.rpm}.el${OS_VERSION}.noarch.rpm
-  fi
-done
-cp -R rpmbuild/RPMS/noarch/*.rpm ${DEST_DIR}/rpms/build
+# Use DIST specific subdirectories
+install -d "${DEST_DIR}/rpms/build/$DISTDIR/RPMS"
+install rpmbuild/RPMS/*/*.rpm "${DEST_DIR}/rpms/build/$DISTDIR/RPMS/"
+install -d "${DEST_DIR}/rpms/build/$DISTDIR/SRPMS"
+install rpmbuild/SRPMS/*.rpm "${DEST_DIR}/rpms/build/$DISTDIR/SRPMS/"
 
 popd
 
-rm -rf ${buildroot}
+#rm -rf ${buildroot}
 


### PR DESCRIPTION
Teach the Docker scripts to set "DIST" based on the "rpm --showrc" value for "dist", and inject it into the bdist_rpm "r--releese" options.
Copy the generated RPMS to the matching "$DISTDIR" subdirectory, so that whatever OS is doing the build generates the RPMS in a matching directory.
Deduce the SRC_DIR even if no command line option is given, rather than failing and exiting.
