### PR TITLE
Adding transform support for subPath

### DIFF
--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 F5 Networks Inc.
+# Copyright 2019 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -181,7 +181,8 @@ def _validate_uri_parts(
     _validate_name_partition_subpath(partition)
     if not kwargs.get('transform_name', False):
         _validate_name_partition_subpath(name)
-    _validate_name_partition_subpath(sub_path)
+    if not kwargs.get('transform_subpath', False):
+        _validate_name_partition_subpath(sub_path)
     if suffix_collections:
         _validate_suffix_collections(suffix_collections)
     return True
@@ -207,8 +208,8 @@ def generate_bigip_uri(base_uri, partition, name, sub_path, suffix, **kwargs):
     'https://0.0.0.0/mgmt/tm/ltm/nat/thwocky'
 
     ::Warning: There are cases where '/' and '~' characters are valid in the
-        object name. This is indicated by passing 'transform_name' boolean as
-        True, by default this is set to False.
+        object name or subPath. This is indicated by passing the 'transform_name' or 'transform_subpath' boolean
+        respectively as True. By default this is set to False.
     '''
 
     _validate_uri_parts(base_uri, partition, name, sub_path, suffix,
@@ -217,6 +218,9 @@ def generate_bigip_uri(base_uri, partition, name, sub_path, suffix, **kwargs):
     if kwargs.get('transform_name', False):
         if name != '':
             name = name.replace('/', '~')
+    if kwargs.get('transform_subpath', False):
+        if sub_path != '':
+            sub_path = sub_path.replace('/', '~')
     if partition != '':
         partition = '~' + partition
     else:
@@ -260,10 +264,12 @@ def decorate_HTTP_verb_method(method):
         identifier, kwargs = _unique_resource_identifier_from_kwargs(**kwargs)
         uri_as_parts = kwargs.pop('uri_as_parts', False)
         transform_name = kwargs.pop('transform_name', False)
+        transform_subpath = kwargs.pop('transform_subpath', False)
         if uri_as_parts:
             REST_uri = generate_bigip_uri(RIC_base_uri, partition, identifier,
                                           sub_path, suffix,
                                           transform_name=transform_name,
+                                          transform_subpath=transform_subpath,
                                           **kwargs)
         else:
             REST_uri = RIC_base_uri

--- a/icontrol/test/unit/test_session.py
+++ b/icontrol/test/unit/test_session.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 F5 Networks Inc.
+# Copyright 2019 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,8 @@ def uparts():
                   'name': 'foobar1',
                   'sub_path': '',
                   'suffix': '/members/m1',
-                  'transform_name': False}
+                  'transform_name': False,
+                  'transform_subpath': False}
     return parts_dict
 
 
@@ -68,7 +69,8 @@ def transform_name():
                   'name': 'foobar1: 1.1.1.1/24 bar1: /Common/DC1',
                   'sub_path': '',
                   'suffix': '/members/m1',
-                  'transform_name': True}
+                  'transform_name': True,
+                  'transform_subpath': False}
     return parts_dict
 
 
@@ -79,7 +81,8 @@ def uparts_with_subpath():
                   'name': 'foobar1',
                   'sub_path': 'sp',
                   'suffix': '/members/m1',
-                  'transform_name': False}
+                  'transform_name': False,
+                  'transform_subpath': False}
     return parts_dict
 
 
@@ -88,9 +91,10 @@ def transform_name_w_subpath():
     parts_dict = {'base_uri': 'https://0.0.0.0/mgmt/tm/root/RESTiface/',
                   'partition': 'BIGCUSTOMER',
                   'name': 'foobar1: 1.1.1.1/24 bar1: /Common/DC1',
-                  'sub_path': 'sp',
+                  'sub_path': 'ltm:/sp',
                   'suffix': '/members/m1',
-                  'transform_name': True}
+                  'transform_name': True,
+                  'transform_subpath': True}
     return parts_dict
 
 
@@ -306,7 +310,7 @@ def test_correct_uri_transformed_nameless_subpath(transform_name_w_subpath):
     transform_name_w_subpath['name'] = ''
     uri = session.generate_bigip_uri(**transform_name_w_subpath)
     assert uri ==\
-        "https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER~sp/members/m1"
+        "https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER~ltm:~sp/members/m1"
 
 
 def test_correct_uri_transformed_partitionless_and_nameless(transform_name):
@@ -376,7 +380,7 @@ def test_correct_uri_transformed_nameless_and_suffixless_subpath(
     transform_name_w_subpath['name'] = ''
     transform_name_w_subpath['suffix'] = ''
     uri = session.generate_bigip_uri(**transform_name_w_subpath)
-    assert uri == 'https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER~sp'
+    assert uri == 'https://0.0.0.0/mgmt/tm/root/RESTiface/~BIGCUSTOMER~ltm:~sp'
 
 
 def test_correct_uri_construction_mgmt_shared(uparts_shared):


### PR DESCRIPTION
Fixes: #163

Problem: Can't submit legitimate query with "/" in subPath

Analysis: Created transform_subpath as duplicate of transform_name

Tests:
- Modified unit tests to include new transform_subpath kwarg
- Added functional test for 11.6.4 (skips on 12.0+ for now)
- Flake8 passing
- All unit/functional tests passing on 11.6.4, 12.1.4, 13.1.1 for py27,py35