### PR TITLE
Resolve #172, Enable HTTP Proxy Support for `iControlRESTTokenAuth` Object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 .idea/*
 *.py[cod]
 
+### Additional virtual environment files
+bin/
+pyvenv.cfg
+
 ### added with RM's Makefile
 localutils/**
 agent/f5/bigip/pycontrol/wsdl/**

--- a/icontrol/session.py
+++ b/icontrol/session.py
@@ -428,22 +428,22 @@ class iControlRESTSession(object):
 
         # Handle token-based auth.
         if token_to_use:
-            self.session.auth = iControlRESTTokenAuth('admin', 'admin')
+            self.session.auth = iControlRESTTokenAuth('admin', 'admin', proxies=proxies)
             self.session.auth.token = token_to_use
         else:
             if auth_provider:
                 self.session.auth = iControlRESTTokenAuth(
-                    username, password, auth_provider=auth_provider, verify=verify
+                    username, password, auth_provider=auth_provider, verify=verify, proxies=proxies
                 )
             else:
                 if token_auth is True:
                     self.session.auth = iControlRESTTokenAuth(
-                        username, password, verify=verify
+                        username, password, verify=verify, proxies=proxies
                     )
                 elif token_auth:
                     # Truthy but not true: non-default loginAuthProvider
                     self.session.auth = iControlRESTTokenAuth(
-                        username, password, token_auth, verify=verify
+                        username, password, token_auth, verify=verify, proxies=proxies
                     )
                 else:
                     self.session.auth = (username, password)


### PR DESCRIPTION
@jasonrahm 
#### What issues does this address?
Fixes #172 

#### What's this change do?
Enable HTTP Proxy support in the `iControlRESTTokenAuth` object by passing the `proxies` from `iControlRESTSession` object down into it, and applying it to the `request.<verb>` calls that take place in that module.

#### Where should the reviewer start?
icontrol/authtoken.py, line 58, then follow it through the `self.proxies` value in that object.

icontrol/session.py, line 432, then follow where `self.proxies` was passed as an argument to the underlying token/auth object.

#### Any background context?
This change is required for full HTTP Proxy functionality.

Otherwise, while the outer `requests.Session` object in `iControlRESTSession` _does_ attempt to utilize the proxies provided to it, the inner token acquisition and validation methods in `iControlRESTTokenAuth` fail as they do not know about the proxy.